### PR TITLE
feat(curvine-csi): default node mount mode to embedded

### DIFF
--- a/curvine-csi/templates/daemonset.yaml
+++ b/curvine-csi/templates/daemonset.yaml
@@ -48,8 +48,8 @@ spec:
               value: "true"
             {{- end }}
             # Mount mode configuration
-            # - "standalone": FUSE runs in independent standalone pod (default, recommended)
-            # - "embedded": FUSE runs in CSI container (legacy mode)
+            # - "embedded": FUSE runs in CSI container (default)
+            # - "standalone": FUSE runs in independent standalone pod (optional, for isolation)
             - name: MOUNT_MODE
               value: {{ .Values.node.mountMode | quote }}
             {{- if eq .Values.node.mountMode "standalone" }}

--- a/curvine-csi/values.yaml
+++ b/curvine-csi/values.yaml
@@ -86,9 +86,9 @@ node:
   fuseDebugEnabled: false
 
   # Mount mode configuration
-  # - "standalone": FUSE runs in independent standalone pod (default, recommended)
-  # - "embedded": FUSE runs in CSI container (legacy mode)
-  mountMode: standalone
+  # - "embedded": FUSE runs in CSI container (default)
+  # - "standalone": FUSE runs in independent standalone pod (optional, for isolation)
+  mountMode: embedded
   
   # Standalone pod configuration
   standalone:


### PR DESCRIPTION
## Summary
- Change `node.mountMode` default from `standalone` to `embedded` in `curvine-csi/values.yaml`
- Update DaemonSet template comments to match the new default

## Test plan
- [x] `helm template test ./curvine-csi` renders `MOUNT_MODE=embedded` on node DaemonSet
- [x] Node DaemonSet no longer injects `STANDALONE_*` env vars under default values
- [ ] `helm upgrade` on an existing standalone deployment should explicitly set `node.mountMode=standalone` if isolation is still required