### PR TITLE
chore(curvine-runtime): update journal snapshot defaults

### DIFF
--- a/curvine-runtime/values.yaml
+++ b/curvine-runtime/values.yaml
@@ -230,8 +230,8 @@ config:
   journal:
     enable: true
     journalDir: "/opt/curvine/data/journal"
-    snapshotInterval: "30s"
-    snapshotEntries: 100
+    snapshotInterval: "6h"
+    snapshotEntries: 1000000
   
   # Worker configuration
   worker:


### PR DESCRIPTION
## Summary
- Change default `config.journal.snapshotInterval` from `30s` to `6h`
- Change default `config.journal.snapshotEntries` from `100` to `1000000`

## Test plan
- [ ] Run `helm template` and verify the configmap renders `snapshot_interval = "6h"` and `snapshot_entries = 1000000`
- [ ] After upgrade, verify journal snapshot behavior matches expectations