### PR TITLE
feat: route runtime logs to console by default

### DIFF
--- a/curvine-runtime/templates/configmap.yaml
+++ b/curvine-runtime/templates/configmap.yaml
@@ -13,6 +13,10 @@ data:
     format_master = {{ .Values.cluster.formatMaster | default false }}
     format_worker = {{ .Values.cluster.formatWorker | default false }}
     enable_s3_gateway = {{ .Values.worker.s3Gateway.enabled | default false }}
+    {{- $logDir := .Values.config.log.logDir }}
+    {{- if .Values.config.log.console }}
+    {{- $logDir = "stdout" }}
+    {{- end }}
 
     {{- $metaDir := .Values.config.master.metaDir }}
     {{- $metaMount := .Values.master.storage.meta.mountPath }}
@@ -44,8 +48,13 @@ data:
     web1_port = {{ .Values.master.web1Port }}
     {{- if .Values.configOverrides.master }}
     {{- range $key, $value := .Values.configOverrides.master }}
+    {{- if not (and $.Values.config.log.console (eq $key "log.log_dir")) }}
     {{ $key }} = {{ toJson $value }}
     {{- end }}
+    {{- end }}
+    {{- end }}
+    {{- if .Values.config.log.console }}
+    log.log_dir = "stdout"
     {{- end }}
 
     [journal]
@@ -76,8 +85,13 @@ data:
     enable_distributed_auth = {{ .Values.worker.s3Gateway.enableDistributedAuth | default true }}
     {{- if .Values.configOverrides.worker }}
     {{- range $key, $value := .Values.configOverrides.worker }}
+    {{- if not (and $.Values.config.log.console (eq $key "log.log_dir")) }}
     {{ $key }} = {{ toJson $value }}
     {{- end }}
+    {{- end }}
+    {{- end }}
+    {{- if .Values.config.log.console }}
+    log.log_dir = "stdout"
     {{- end }}
 
     [s3_gateway]
@@ -106,9 +120,11 @@ data:
 
     [log]
     level = "{{ .Values.config.log.level }}"
-    log_dir = "{{ .Values.config.log.logDir }}"
+    log_dir = "{{ $logDir }}"
     {{- if .Values.configOverrides.log }}
     {{- range $key, $value := .Values.configOverrides.log }}
+    {{- if not (and $.Values.config.log.console (eq $key "log_dir")) }}
     {{ $key }} = {{ toJson $value }}
+    {{- end }}
     {{- end }}
     {{- end }}

--- a/curvine-runtime/values.schema.json
+++ b/curvine-runtime/values.schema.json
@@ -355,7 +355,20 @@
           "type": "object"
         },
         "log": {
-          "type": "object"
+          "type": "object",
+          "properties": {
+            "level": {
+              "type": "string",
+              "minLength": 1
+            },
+            "logDir": {
+              "type": "string"
+            },
+            "console": {
+              "type": "boolean"
+            }
+          },
+          "additionalProperties": true
         }
       },
       "additionalProperties": true

--- a/curvine-runtime/values.yaml
+++ b/curvine-runtime/values.yaml
@@ -263,6 +263,9 @@ config:
   log:
     level: "INFO"
     logDir: "/opt/curvine/logs"
+    # When true, route Curvine service logs to stdout for kubectl logs.
+    # This follows the same intent as StarRocks LOG_CONSOLE=1.
+    console: true
 
 # Configuration overrides by section
 # These allow you to override specific configuration items in each section


### PR DESCRIPTION
## Summary
- Add `config.log.console` to route Curvine runtime logs to stdout by default.
- Render master, worker, and global log sections with `stdout` when console logging is enabled.
- Preserve file logging with `--set config.log.console=false`.

## Test Plan
- `helm template cv /tmp/curvine-helm-log-console/curvine-runtime -n default -f /tmp/cv-values.yaml --show-only templates/configmap.yaml`
- `helm template cv /tmp/curvine-helm-log-console/curvine-runtime -n default -f /tmp/cv-values.yaml --set config.log.console=false --show-only templates/configmap.yaml`
- `helm lint /tmp/curvine-helm-log-console/curvine-runtime -f /tmp/cv-values.yaml`
- `helm lint /tmp/curvine-helm-log-console/curvine-runtime -f /tmp/cv-values.yaml --set config.log.console=false`
- Live cluster check: new master/worker pods emit Curvine INFO/WARN lines through `kubectl logs` after `config.log.console=true` upgrade.