### PR TITLE
feat: default image tag from Chart.AppVersion

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -48,12 +48,14 @@ Behavior:
 
 ## Versioning Rules
 
-| Trigger | Chart Version |
-| --- | --- |
-| `main` push | `<base>-dev` |
-| `v*` tag push | `<tag without v>` |
-| Manual branch build | `<base>-dev` |
-| Manual tag build | `<tag without v>` |
+| Trigger | Chart Version | App Version | Default Image Tag |
+| --- | --- | --- | --- |
+| `main` push | `<base>-dev` | `<base>-dev` | `v<base>-dev` (override with `--set image.tag=latest` for dev images) |
+| `v*` tag push | `<tag without v>` | `<tag without v>` | `v<tag without v>` |
+| Manual branch build | `<base>-dev` | `<base>-dev` | `v<base>-dev` |
+| Manual tag build | `<tag without v>` | `<tag without v>` | `v<tag without v>` |
+
+`values.yaml` leaves `image.tag` empty by default; templates resolve it to `v{Chart.AppVersion}`.
 
 ## Operator Installation
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -131,8 +131,9 @@ jobs:
           fi
 
           sed -i "s/^version:.*/version: $FINAL_VERSION/" ${{ matrix.chart.path }}/Chart.yaml
+          sed -i "s/^appVersion:.*/appVersion: \"$FINAL_VERSION\"/" ${{ matrix.chart.path }}/Chart.yaml
           echo "version=$FINAL_VERSION" >> $GITHUB_OUTPUT
-          echo "Updated Chart.yaml version to: $FINAL_VERSION"
+          echo "Updated Chart.yaml version and appVersion to: $FINAL_VERSION"
           cat ${{ matrix.chart.path }}/Chart.yaml
 
       - name: Validate Helm chart

--- a/curvine-csi/README.md
+++ b/curvine-csi/README.md
@@ -52,7 +52,7 @@ helm upgrade --install curvine-csi ./curvine-csi \
 | Key | Description | Default |
 | --- | --- | --- |
 | `image.repository` | CSI image repository | `ghcr.io/curvineio/curvine-csi` |
-| `image.tag` | CSI image tag | `latest` |
+| `image.tag` | CSI image tag (empty uses `v{Chart.AppVersion}`) | `""` |
 | `csiDriver.name` | CSI driver name | `curvine` |
 | `controller.replicas` | Controller replica count | `1` |
 | `node.mountMode` | FUSE mount strategy | `standalone` |

--- a/curvine-csi/templates/_helpers.tpl
+++ b/curvine-csi/templates/_helpers.tpl
@@ -88,3 +88,31 @@ Create the name for node cluster role
 {{- define "curvine-csi.nodeClusterRoleName" -}}
 {{- printf "%s-%s" (include "curvine-csi.fullname" .) "node" | trunc 63 | trimSuffix "-" }}
 {{- end }}
+
+{{/*
+Image tag defaults to v{Chart.AppVersion} when values.image.tag is empty.
+*/}}
+{{- define "curvine-csi.imageTag" -}}
+{{- if .Values.image.tag -}}
+{{- .Values.image.tag -}}
+{{- else if hasPrefix "v" .Chart.AppVersion -}}
+{{- .Chart.AppVersion -}}
+{{- else -}}
+{{- printf "v%s" .Chart.AppVersion -}}
+{{- end -}}
+{{- end }}
+
+{{/*
+Full CSI image reference
+*/}}
+{{- define "curvine-csi.image" -}}
+{{- printf "%s:%s" .Values.image.repository (include "curvine-csi.imageTag" .) }}
+{{- end }}
+
+{{/*
+Standalone FUSE pod image reference (repository may differ from CSI image)
+*/}}
+{{- define "curvine-csi.standaloneImage" -}}
+{{- $repository := .Values.node.standalone.image | default .Values.image.repository -}}
+{{- printf "%s:%s" $repository (include "curvine-csi.imageTag" .) }}
+{{- end }}

--- a/curvine-csi/templates/daemonset.yaml
+++ b/curvine-csi/templates/daemonset.yaml
@@ -25,7 +25,7 @@ spec:
       dnsPolicy: {{ .Values.node.dnsPolicy }}
       containers:
         - name: {{ .Values.node.container.name }}
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          image: {{ include "curvine-csi.image" . | quote }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           command: {{ .Values.node.container.command | toJson }}
           args:
@@ -55,7 +55,7 @@ spec:
             {{- if eq .Values.node.mountMode "standalone" }}
             # Standalone pod configuration
             - name: STANDALONE_IMAGE
-              value: "{{ .Values.node.standalone.image | default .Values.image.repository }}:{{ .Values.image.tag }}"
+              value: {{ include "curvine-csi.standaloneImage" . | quote }}
             - name: STANDALONE_SERVICE_ACCOUNT
               value: {{ include "curvine-csi.nodeServiceAccountName" . | quote }}
             - name: STANDALONE_CPU_REQUEST

--- a/curvine-csi/templates/deployment.yaml
+++ b/curvine-csi/templates/deployment.yaml
@@ -25,7 +25,7 @@ spec:
       {{- end }}
       containers:
         - name: {{ .Values.controller.container.name }}
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          image: {{ include "curvine-csi.image" . | quote }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           command: {{ .Values.controller.container.command | toJson }}
           args:
@@ -46,7 +46,7 @@ spec:
             - name: MOUNT_MODE
               value: {{ .Values.node.mountMode | quote }}
             - name: STANDALONE_IMAGE
-              value: "{{ .Values.node.standalone.image | default .Values.image.repository }}:{{ .Values.image.tag }}"
+              value: {{ include "curvine-csi.standaloneImage" . | quote }}
             - name: STANDALONE_SERVICE_ACCOUNT
               value: {{ include "curvine-csi.nodeServiceAccountName" . | quote }}
           livenessProbe:

--- a/curvine-csi/values.schema.json
+++ b/curvine-csi/values.schema.json
@@ -11,7 +11,7 @@
         },
         "tag": {
           "type": "string",
-          "minLength": 1
+          "description": "Container image tag. Empty string uses v{Chart.AppVersion}."
         },
         "pullPolicy": {
           "type": "string",

--- a/curvine-csi/values.yaml
+++ b/curvine-csi/values.yaml
@@ -4,7 +4,8 @@
 # Image settings
 image:
   repository: ghcr.io/curvineio/curvine-csi
-  tag: v0.2.0-alpha
+  # Leave empty to use v{Chart.AppVersion} (matches curvine release image tags)
+  tag: ""
   pullPolicy: Always
 
 # CSI Driver settings

--- a/curvine-runtime/templates/_helpers.tpl
+++ b/curvine-runtime/templates/_helpers.tpl
@@ -190,10 +190,24 @@ imagePullSecrets:
 {{- end }}
 
 {{/*
+Image tag defaults to v{Chart.AppVersion} when values.image.tag is empty.
+Curvine container images use a v-prefixed tag (e.g. v0.3.0); Chart.AppVersion omits the prefix.
+*/}}
+{{- define "curvine.imageTag" -}}
+{{- if .Values.image.tag -}}
+{{- .Values.image.tag -}}
+{{- else if hasPrefix "v" .Chart.AppVersion -}}
+{{- .Chart.AppVersion -}}
+{{- else -}}
+{{- printf "v%s" .Chart.AppVersion -}}
+{{- end -}}
+{{- end }}
+
+{{/*
 Full image name
 */}}
 {{- define "curvine.image" -}}
-{{- printf "%s:%s" .Values.image.repository .Values.image.tag }}
+{{- printf "%s:%s" .Values.image.repository (include "curvine.imageTag" .) }}
 {{- end }}
 
 {{/*

--- a/curvine-runtime/values.schema.json
+++ b/curvine-runtime/values.schema.json
@@ -40,7 +40,7 @@
         },
         "tag": {
           "type": "string",
-          "minLength": 1
+          "description": "Container image tag. Empty string uses v{Chart.AppVersion}."
         },
         "pullPolicy": {
           "type": "string",

--- a/curvine-runtime/values.yaml
+++ b/curvine-runtime/values.yaml
@@ -12,7 +12,8 @@ cluster:
 # Image configuration
 image:
   repository: ghcr.io/curvineio/curvine
-  tag: "v0.2.0-alpha"
+  # Leave empty to use v{Chart.AppVersion} (matches curvine release image tags)
+  tag: ""
   pullPolicy: IfNotPresent
   pullSecrets: []
 


### PR DESCRIPTION
## Summary
- Default container image tags to `v{Chart.AppVersion}` when `values.image.tag` is empty in both `curvine-runtime` and `curvine-csi` charts
- Sync `appVersion` alongside `version` in the release workflow so chart releases stay aligned with curvine image tags
- Remove hardcoded image tags from `values.yaml`; users can still override via `--set image.tag=...`

## Test plan
- [x] `helm lint curvine-runtime`
- [x] `helm lint curvine-csi`
- [x] `helm template test curvine-runtime` renders `ghcr.io/curvineio/curvine:v0.2.0-alpha`
- [x] `helm template test curvine-csi --set image.tag=v9.9.9` respects override
- [ ] Tag a `v*` release and verify packaged chart uses matching `appVersion` and default image tag