### PR TITLE
docs: explain chart version, appVersion, and image tag mapping

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,88 @@ curvine-helm/
 - The public Helm index is served from `curvine-doc`.
 - End users should install from `https://curvineio.github.io/curvine-doc/helm-charts`.
 
+## Versioning Model
+
+Curvine uses separate repositories for application code, container images, and Helm charts. The
+version fields below keep those artifacts aligned without requiring manual image tag edits on
+every release.
+
+### Version Fields
+
+| Field | Example | Where It Lives | Meaning |
+| --- | --- | --- | --- |
+| Curvine git tag | `v0.3.0` | `CurvineIO/curvine` | Application release tag |
+| Container image tag | `v0.3.0` | `ghcr.io/curvineio/curvine`, `ghcr.io/curvineio/curvine-csi` | Image built from the matching Curvine tag |
+| Helm git tag | `v0.3.0` | `CurvineIO/curvine-helm` | Chart release tag in this repository |
+| `Chart.version` | `0.3.0` | `Chart.yaml` | Helm chart package version |
+| `Chart.appVersion` | `0.3.0` | `Chart.yaml` | Application version deployed by the chart |
+| `values.image.tag` | `""` | `values.yaml` | Optional image tag override |
+
+### How They Relate
+
+```mermaid
+flowchart LR
+  A["curvine tag<br/>v0.3.0"] --> B["container image<br/>v0.3.0"]
+  C["curvine-helm tag<br/>v0.3.0"] --> D["Chart.version<br/>0.3.0"]
+  C --> E["Chart.appVersion<br/>0.3.0"]
+  E --> F["default image tag<br/>v0.3.0"]
+  B -. same version .- F
+```
+
+Rules:
+
+1. **Curvine release drives images.** Pushing `v0.3.0` in `CurvineIO/curvine` builds and publishes
+   `ghcr.io/curvineio/curvine:v0.3.0` and `ghcr.io/curvineio/curvine-csi:v0.3.0`.
+2. **Helm release drives chart metadata.** Pushing `v0.3.0` in this repository packages charts with
+   `version: 0.3.0` and `appVersion: "0.3.0"`.
+3. **Image tag defaults from `appVersion`.** `values.yaml` leaves `image.tag` empty. Templates
+   resolve it to `v{Chart.AppVersion}` (for example `0.3.0` becomes `v0.3.0`).
+4. **`Chart.version` and `Chart.appVersion` usually match** for application releases. They can
+   diverge when only chart templates or defaults change without a new Curvine application release.
+5. **Override when needed.** Use `--set image.tag=...` for custom images, hotfixes, or dev builds.
+
+### Release Mapping
+
+| Trigger in `curvine-helm` | `Chart.version` | `Chart.appVersion` | Default `image.tag` |
+| --- | --- | --- | --- |
+| Push `v0.3.0` tag | `0.3.0` | `0.3.0` | `v0.3.0` |
+| Push to `main` | `<base>-dev` | `<base>-dev` | `v<base>-dev` |
+
+For `main` branch test packages, the default image tag may not exist in the registry. Use
+`--set image.tag=latest` when installing a `-dev` chart against development images.
+
+### Example: Versioned Release
+
+```bash
+# 1. Curvine publishes application binaries and images
+#    CurvineIO/curvine tag: v0.3.0
+#    images: ghcr.io/curvineio/curvine:v0.3.0
+#            ghcr.io/curvineio/curvine-csi:v0.3.0
+
+# 2. This repository publishes matching Helm charts
+git tag v0.3.0
+git push origin v0.3.0
+# chart package version: 0.3.0
+# chart appVersion: 0.3.0
+# rendered image: ghcr.io/curvineio/curvine:v0.3.0
+
+# 3. Install from the public Helm repository
+helm repo add curvineio https://curvineio.github.io/curvine-doc/helm-charts
+helm repo update
+helm upgrade --install curvine curvineio/curvine --version 0.3.0 -n curvine --create-namespace
+```
+
+### Example: Override Image Tag
+
+```bash
+helm upgrade --install curvine curvineio/curvine \
+  --set image.tag=v0.3.0-rc.1 \
+  -n curvine --create-namespace
+```
+
+For workflow details and the release checklist, see
+[.github/workflows/README.md](./.github/workflows/README.md).
+
 ## Local Development
 
 Lint and package from source directories:


### PR DESCRIPTION
## Summary
- Add a **Versioning Model** section to the repository README
- Document the relationship between Curvine git tags, container image tags, Helm chart `version` / `appVersion`, and default `image.tag`
- Include release mapping tables, examples, and a mermaid diagram

## Test plan
- [x] Reviewed README rendering locally
- [ ] Verify mermaid diagram renders correctly on GitHub