### PR TITLE
feat: use latest appVersion for main branch chart builds

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -50,12 +50,13 @@ Behavior:
 
 | Trigger | Chart Version | App Version | Default Image Tag |
 | --- | --- | --- | --- |
-| `main` push | `<base>-dev` | `<base>-dev` | `v<base>-dev` (override with `--set image.tag=latest` for dev images) |
+| `main` push | `<base>-dev` | `latest` | `latest` |
 | `v*` tag push | `<tag without v>` | `<tag without v>` | `v<tag without v>` |
-| Manual branch build | `<base>-dev` | `<base>-dev` | `v<base>-dev` |
+| Manual branch build | `<base>-dev` | `latest` | `latest` |
 | Manual tag build | `<tag without v>` | `<tag without v>` | `v<tag without v>` |
 
-`values.yaml` leaves `image.tag` empty by default; templates resolve it to `v{Chart.AppVersion}`.
+`values.yaml` leaves `image.tag` empty by default. Templates resolve it to `latest` when
+`Chart.AppVersion` is `latest`, otherwise `v{Chart.AppVersion}`.
 
 ## Operator Installation
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -126,14 +126,16 @@ jobs:
           echo "Base version: $BASE_VERSION"
           if [ "${{ steps.tag.outputs.is_branch_build }}" == "true" ]; then
             FINAL_VERSION="${BASE_VERSION}-dev"
+            APP_VERSION="latest"
           else
             FINAL_VERSION="${{ steps.tag.outputs.version }}"
+            APP_VERSION="${FINAL_VERSION}"
           fi
 
           sed -i "s/^version:.*/version: $FINAL_VERSION/" ${{ matrix.chart.path }}/Chart.yaml
-          sed -i "s/^appVersion:.*/appVersion: \"$FINAL_VERSION\"/" ${{ matrix.chart.path }}/Chart.yaml
+          sed -i "s/^appVersion:.*/appVersion: \"$APP_VERSION\"/" ${{ matrix.chart.path }}/Chart.yaml
           echo "version=$FINAL_VERSION" >> $GITHUB_OUTPUT
-          echo "Updated Chart.yaml version and appVersion to: $FINAL_VERSION"
+          echo "Updated Chart.yaml version to: $FINAL_VERSION, appVersion to: $APP_VERSION"
           cat ${{ matrix.chart.path }}/Chart.yaml
 
       - name: Validate Helm chart

--- a/README.md
+++ b/README.md
@@ -102,20 +102,21 @@ Rules:
 2. **Helm release drives chart metadata.** Pushing `v0.3.0` in this repository packages charts with
    `version: 0.3.0` and `appVersion: "0.3.0"`.
 3. **Image tag defaults from `appVersion`.** `values.yaml` leaves `image.tag` empty. Templates
-   resolve it to `v{Chart.AppVersion}` (for example `0.3.0` becomes `v0.3.0`).
-4. **`Chart.version` and `Chart.appVersion` usually match** for application releases. They can
-   diverge when only chart templates or defaults change without a new Curvine application release.
-5. **Override when needed.** Use `--set image.tag=...` for custom images, hotfixes, or dev builds.
+   resolve it to `latest` when `Chart.AppVersion` is `latest`, otherwise `v{Chart.AppVersion}`
+   (for example `0.3.0` becomes `v0.3.0`).
+4. **`Chart.version` and `Chart.appVersion` usually match** for versioned releases. For `main`
+   branch test packages, `Chart.version` stays `<base>-dev` while `appVersion` is `latest`.
+5. **Override when needed.** Use `--set image.tag=...` for custom images, hotfixes, or pinned builds.
 
 ### Release Mapping
 
 | Trigger in `curvine-helm` | `Chart.version` | `Chart.appVersion` | Default `image.tag` |
 | --- | --- | --- | --- |
 | Push `v0.3.0` tag | `0.3.0` | `0.3.0` | `v0.3.0` |
-| Push to `main` | `<base>-dev` | `<base>-dev` | `v<base>-dev` |
+| Push to `main` | `<base>-dev` | `latest` | `latest` |
 
-For `main` branch test packages, the default image tag may not exist in the registry. Use
-`--set image.tag=latest` when installing a `-dev` chart against development images.
+`main` branch test packages use rolling `latest` images from the registry. The chart package
+version remains `<base>-dev` so it does not collide with versioned releases.
 
 ### Example: Versioned Release
 

--- a/README.md
+++ b/README.md
@@ -75,16 +75,22 @@ every release.
 
 ### Version Fields
 
-| Field | Example | Where It Lives | Meaning |
-| --- | --- | --- | --- |
-| Curvine git tag | `v0.3.0` | `CurvineIO/curvine` | Application release tag |
-| Container image tag | `v0.3.0` | `ghcr.io/curvineio/curvine`, `ghcr.io/curvineio/curvine-csi` | Image built from the matching Curvine tag |
-| Helm git tag | `v0.3.0` | `CurvineIO/curvine-helm` | Chart release tag in this repository |
-| `Chart.version` | `0.3.0` | `Chart.yaml` | Helm chart package version |
-| `Chart.appVersion` | `0.3.0` | `Chart.yaml` | Application version deployed by the chart |
-| `values.image.tag` | `""` | `values.yaml` | Optional image tag override |
+| Field | Versioned Release Example | Main Branch Dev Example | Where It Lives | Meaning |
+| --- | --- | --- | --- | --- |
+| Curvine git tag | `v0.3.0` | — | `CurvineIO/curvine` | Application release tag |
+| Container image tag | `v0.3.0` | `latest` | `ghcr.io/curvineio/curvine`, `ghcr.io/curvineio/curvine-csi` | Image pulled by workloads |
+| Helm git tag | `v0.3.0` | — | `CurvineIO/curvine-helm` | Chart release tag in this repository |
+| `Chart.version` | `0.3.0` | `0.2.0-dev` | `Chart.yaml` | Helm chart package version |
+| `Chart.appVersion` | `0.3.0` | `latest` | `Chart.yaml` | Application version deployed by the chart |
+| `values.image.tag` | `""` | `""` | `values.yaml` | Optional image tag override |
+
+`Chart.version` identifies the chart package. `Chart.appVersion` identifies the application
+binaries/images the chart deploys. They match on versioned releases, but diverge on `main`
+branch test packages.
 
 ### How They Relate
+
+Versioned release:
 
 ```mermaid
 flowchart LR
@@ -93,6 +99,16 @@ flowchart LR
   C --> E["Chart.appVersion<br/>0.3.0"]
   E --> F["default image tag<br/>v0.3.0"]
   B -. same version .- F
+```
+
+`main` branch test package:
+
+```mermaid
+flowchart LR
+  M["push to main"] --> CV["Chart.version<br/>0.2.0-dev"]
+  M --> AV["Chart.appVersion<br/>latest"]
+  AV --> IT["default image tag<br/>latest"]
+  IMG["container image<br/>latest"] -. rolling image .- IT
 ```
 
 Rules:
@@ -138,6 +154,23 @@ helm repo add curvineio https://curvineio.github.io/curvine-doc/helm-charts
 helm repo update
 helm upgrade --install curvine curvineio/curvine --version 0.3.0 -n curvine --create-namespace
 ```
+
+### Example: Main Branch Dev Release
+
+```bash
+# 1. Merge chart changes to main
+#    GitHub Actions packages charts into the `latest` test release:
+#    chart package version: 0.2.0-dev
+#    chart appVersion: latest
+#    rendered image: ghcr.io/curvineio/curvine:latest
+
+# 2. Install the rolling test package from GitHub Releases
+wget https://github.com/CurvineIO/curvine-helm/releases/download/latest/curvine-0.2.0-dev.tgz
+helm upgrade --install curvine ./curvine-0.2.0-dev.tgz -n curvine --create-namespace
+```
+
+Use this flow for chart development and integration testing only. For production, install a
+versioned chart that matches a Curvine release tag.
 
 ### Example: Override Image Tag
 

--- a/curvine-csi/README.md
+++ b/curvine-csi/README.md
@@ -9,6 +9,22 @@ Helm chart for deploying the Curvine CSI driver.
 - Recommended release name: `curvine-csi`
 - Recommended namespace: `curvine-system`
 
+## Versioning and Images
+
+This chart leaves `values.image.tag` empty by default. Templates resolve the effective image tag
+from `Chart.appVersion`:
+
+| `Chart.appVersion` | Default image tag |
+| --- | --- |
+| `0.3.0` | `v0.3.0` |
+| `latest` | `latest` |
+
+On versioned releases, `Chart.version` and `Chart.appVersion` match. On `main` branch test
+packages, `Chart.version` is `<base>-dev` while `appVersion` is `latest`.
+
+See the repository [README](../README.md#versioning-model) for the full version mapping and
+release workflow.
+
 ## Prerequisites
 
 - Kubernetes 1.19+
@@ -52,7 +68,7 @@ helm upgrade --install curvine-csi ./curvine-csi \
 | Key | Description | Default |
 | --- | --- | --- |
 | `image.repository` | CSI image repository | `ghcr.io/curvineio/curvine-csi` |
-| `image.tag` | CSI image tag (empty uses `v{Chart.AppVersion}`) | `""` |
+| `image.tag` | CSI image tag (empty uses `latest` when `Chart.AppVersion` is `latest`, otherwise `v{Chart.AppVersion}`) | `""` |
 | `csiDriver.name` | CSI driver name | `curvine` |
 | `controller.replicas` | Controller replica count | `1` |
 | `node.mountMode` | FUSE mount strategy | `standalone` |

--- a/curvine-csi/templates/_helpers.tpl
+++ b/curvine-csi/templates/_helpers.tpl
@@ -95,6 +95,8 @@ Image tag defaults to v{Chart.AppVersion} when values.image.tag is empty.
 {{- define "curvine-csi.imageTag" -}}
 {{- if .Values.image.tag -}}
 {{- .Values.image.tag -}}
+{{- else if eq .Chart.AppVersion "latest" -}}
+{{- "latest" -}}
 {{- else if hasPrefix "v" .Chart.AppVersion -}}
 {{- .Chart.AppVersion -}}
 {{- else -}}

--- a/curvine-runtime/README.md
+++ b/curvine-runtime/README.md
@@ -11,7 +11,21 @@ Helm chart for deploying a Curvine runtime cluster on Kubernetes.
 
 When installing from a Helm repository, use `curvineio/curvine`. When installing from this repository, use `./curvine-runtime`.
 
-## Before You Install
+## Versioning and Images
+
+This chart leaves `values.image.tag` empty by default. Templates resolve the effective image tag
+from `Chart.appVersion`:
+
+| `Chart.appVersion` | Default image tag |
+| --- | --- |
+| `0.3.0` | `v0.3.0` |
+| `latest` | `latest` |
+
+On versioned releases, `Chart.version` and `Chart.appVersion` match. On `main` branch test
+packages, `Chart.version` is `<base>-dev` while `appVersion` is `latest`.
+
+See the repository [README](../README.md#versioning-model) for the full version mapping and
+release workflow.
 
 Confirm these prerequisites first:
 

--- a/curvine-runtime/templates/_helpers.tpl
+++ b/curvine-runtime/templates/_helpers.tpl
@@ -196,6 +196,8 @@ Curvine container images use a v-prefixed tag (e.g. v0.3.0); Chart.AppVersion om
 {{- define "curvine.imageTag" -}}
 {{- if .Values.image.tag -}}
 {{- .Values.image.tag -}}
+{{- else if eq .Chart.AppVersion "latest" -}}
+{{- "latest" -}}
 {{- else if hasPrefix "v" .Chart.AppVersion -}}
 {{- .Chart.AppVersion -}}
 {{- else -}}


### PR DESCRIPTION
## Summary
- Set `appVersion: latest` (while keeping `Chart.version` as `<base>-dev`) for `main` branch and manual branch builds
- Resolve default `image.tag` to `latest` when `Chart.AppVersion` is `latest`
- Update repository and workflow README versioning tables

## Test plan
- [x] `helm lint curvine-runtime`
- [x] `helm lint curvine-csi`
- [x] `helm template` with `appVersion: latest` renders `ghcr.io/curvineio/curvine:latest`
- [ ] Push to `main` and verify packaged `-dev` chart metadata uses `appVersion: latest`