### PR TITLE
feat(ci): create helm release tag on curvine repository_dispatch

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -18,6 +18,21 @@ This repository publishes chart packages from source directories and serves the 
 
 ## Triggers
 
+### `repository_dispatch` from Curvine
+
+- Event type: `curvine-release`
+- Workflow: `on-curvine-release.yml`
+- Triggered after `CurvineIO/curvine` publishes runtime and CSI images for a `v*` tag
+- Creates the matching `v*` git tag on `main` if it does not already exist
+- The tag push then runs the standard chart packaging workflow
+
+Manual retry:
+
+```bash
+# In curvine-helm Actions -> "On Curvine Release" -> Run workflow
+# tag: v0.3.0
+```
+
 ### Push to `main`
 
 - Packages both charts with a fixed `-dev` chart version
@@ -72,10 +87,29 @@ helm upgrade --install curvine-csi curvineio/curvine-csi
 
 ## Release Checklist
 
+### Automated path (recommended)
+
+1. Push a `v*` tag in `CurvineIO/curvine`.
+2. Wait for Curvine image builds and the helm dispatch workflow to complete.
+3. Confirm `curvine-helm` created the matching `v*` tag and GitHub Release.
+4. Manually run the release workflow with `ref=<v-tag>` and `sync_to_doc=true` when you are ready to publish the updated public index.
+
+### Manual path
+
 1. Update chart source and documentation.
 2. Push to `main` if you need a test package in the `latest` release.
 3. Create and push a `v*` tag for a versioned release.
 4. Manually run the workflow with `ref=<v-tag>` and `sync_to_doc=true` when you are ready to publish the updated index.
+
+## Repository Secrets
+
+`CurvineIO/curvine` must define:
+
+| Secret | Used by | Purpose |
+| --- | --- | --- |
+| `CURVINE_HELM_DISPATCH_TOKEN` | `trigger-helm-release.yml` | PAT with read/write access to `CurvineIO/curvine-helm` so it can send `repository_dispatch` events |
+
+Create a fine-grained PAT or classic PAT with `contents: write` on `curvine-helm`, then add it to the Curvine repository secrets.
 
 ## Notes
 

--- a/.github/workflows/on-curvine-release.yml
+++ b/.github/workflows/on-curvine-release.yml
@@ -1,0 +1,103 @@
+name: On Curvine Release
+
+on:
+  repository_dispatch:
+    types: [curvine-release]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Release tag to create (e.g. v0.3.0)'
+        required: true
+        type: string
+      source_sha:
+        description: 'Source curvine commit SHA (optional, for audit trail)'
+        required: false
+        type: string
+      source_repository:
+        description: 'Source repository (optional)'
+        required: false
+        type: string
+        default: CurvineIO/curvine
+
+permissions:
+  contents: write
+
+concurrency:
+  group: on-curvine-release-${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.event.client_payload.tag }}
+  cancel-in-progress: false
+
+jobs:
+  create-release-tag:
+    name: Create helm release tag
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Resolve release metadata
+        id: meta
+        run: |
+          if [ "${{ github.event_name }}" = "repository_dispatch" ]; then
+            TAG='${{ github.event.client_payload.tag }}'
+            SOURCE_SHA='${{ github.event.client_payload.sha }}'
+            SOURCE_REPO='${{ github.event.client_payload.repository }}'
+          else
+            TAG='${{ inputs.tag }}'
+            SOURCE_SHA='${{ inputs.source_sha }}'
+            SOURCE_REPO='${{ inputs.source_repository }}'
+          fi
+
+          if [[ ! "$TAG" =~ ^v ]]; then
+            echo "::error::Release tag must start with v, got: $TAG"
+            exit 1
+          fi
+
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+          echo "version=${TAG#v}" >> "$GITHUB_OUTPUT"
+          echo "source_sha=$SOURCE_SHA" >> "$GITHUB_OUTPUT"
+          echo "source_repo=$SOURCE_REPO" >> "$GITHUB_OUTPUT"
+          echo "Helm release tag: $TAG"
+          echo "Source: ${SOURCE_REPO}@${SOURCE_SHA}"
+
+      - name: Check whether tag already exists
+        id: check
+        run: |
+          if git rev-parse "refs/tags/${{ steps.meta.outputs.tag }}" >/dev/null 2>&1; then
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            echo "Tag ${{ steps.meta.outputs.tag }} already exists; skipping tag creation"
+          else
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Create and push release tag
+        if: steps.check.outputs.skip != 'true'
+        env:
+          TAG: ${{ steps.meta.outputs.tag }}
+          SOURCE_REPO: ${{ steps.meta.outputs.source_repo }}
+          SOURCE_SHA: ${{ steps.meta.outputs.source_sha }}
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+          git tag -a "$TAG" -m "Release ${TAG}
+
+          Triggered by Curvine release pipeline.
+          Source repository: ${SOURCE_REPO}
+          Source commit: ${SOURCE_SHA}"
+
+          git push origin "$TAG"
+
+      - name: Release summary
+        run: |
+          {
+            echo "## Curvine Helm Release Trigger"
+            echo "- **Tag**: ${{ steps.meta.outputs.tag }}"
+            echo "- **Chart version**: ${{ steps.meta.outputs.version }}"
+            echo "- **Source repository**: ${{ steps.meta.outputs.source_repo }}"
+            echo "- **Source commit**: ${{ steps.meta.outputs.source_sha }}"
+            echo "- **Tag action**: ${{ steps.check.outputs.skip == 'true' && 'skipped (already exists)' || 'created and pushed' }}"
+            echo ""
+            echo "The existing release workflow packages charts when a \`v*\` tag is pushed."
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/README.md
+++ b/README.md
@@ -115,14 +115,17 @@ Rules:
 
 1. **Curvine release drives images.** Pushing `v0.3.0` in `CurvineIO/curvine` builds and publishes
    `ghcr.io/curvineio/curvine:v0.3.0` and `ghcr.io/curvineio/curvine-csi:v0.3.0`.
-2. **Helm release drives chart metadata.** Pushing `v0.3.0` in this repository packages charts with
-   `version: 0.3.0` and `appVersion: "0.3.0"`.
-3. **Image tag defaults from `appVersion`.** `values.yaml` leaves `image.tag` empty. Templates
+2. **Helm release follows automatically.** After Curvine images are published, `CurvineIO/curvine`
+   dispatches a `curvine-release` event to this repository. The `on-curvine-release` workflow
+   creates the matching `v*` git tag on `main`, which triggers chart packaging.
+3. **Helm release drives chart metadata.** The release workflow packages charts with
+   `version: 0.3.0` and `appVersion: "0.3.0"` from the git tag.
+4. **Image tag defaults from `appVersion`.** `values.yaml` leaves `image.tag` empty. Templates
    resolve it to `latest` when `Chart.AppVersion` is `latest`, otherwise `v{Chart.AppVersion}`
    (for example `0.3.0` becomes `v0.3.0`).
-4. **`Chart.version` and `Chart.appVersion` usually match** for versioned releases. For `main`
+5. **`Chart.version` and `Chart.appVersion` usually match** for versioned releases. For `main`
    branch test packages, `Chart.version` stays `<base>-dev` while `appVersion` is `latest`.
-5. **Override when needed.** Use `--set image.tag=...` for custom images, hotfixes, or pinned builds.
+6. **Override when needed.** Use `--set image.tag=...` for custom images, hotfixes, or pinned builds.
 
 ### Release Mapping
 
@@ -142,12 +145,13 @@ version remains `<base>-dev` so it does not collide with versioned releases.
 #    images: ghcr.io/curvineio/curvine:v0.3.0
 #            ghcr.io/curvineio/curvine-csi:v0.3.0
 
-# 2. This repository publishes matching Helm charts
-git tag v0.3.0
-git push origin v0.3.0
-# chart package version: 0.3.0
-# chart appVersion: 0.3.0
-# rendered image: ghcr.io/curvineio/curvine:v0.3.0
+# 2. Curvine dispatches a helm release for the same tag
+#    curvine-helm receives repository_dispatch event: curvine-release
+#    on-curvine-release workflow creates tag v0.3.0 on main
+#    release workflow packages charts:
+#    chart package version: 0.3.0
+#    chart appVersion: 0.3.0
+#    rendered image: ghcr.io/curvineio/curvine:v0.3.0
 
 # 3. Install from the public Helm repository
 helm repo add curvineio https://curvineio.github.io/curvine-doc/helm-charts


### PR DESCRIPTION
## Summary
- Add `on-curvine-release.yml` to handle `repository_dispatch` event `curvine-release`
- Create and push the matching `v*` git tag on `main` when it does not already exist
- Reuse existing `release.yml` for chart packaging driven by `Chart.appVersion`
- Document automated release flow and required cross-repo secret

## Test plan
- [ ] Merge paired PR in `curvine`
- [x] Configure `CURVINE_HELM_DISPATCH_TOKEN` in `curvine`
- [ ] Trigger `On Curvine Release` manually with a test tag, or run end-to-end from a `v*` curvine tag
- [ ] Verify GitHub Release is created for the helm tag