### PR TITLE
fix(runtime): bundle Kruise subchart and fix snapshot_entries rendering

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -141,13 +141,25 @@ jobs:
       - name: Validate Helm chart
         run: |
           cd ${{ matrix.chart.path }}
+          if [ "${{ matrix.chart.name }}" = "curvine" ]; then
+            helm repo add openkruise https://openkruise.github.io/charts/
+            helm dependency build .
+          fi
           helm lint .
+          if [ "${{ matrix.chart.name }}" = "curvine" ]; then
+            helm template test . | grep 'snapshot_entries = 1000000'
+            helm template test . | grep 'snapshot_entries' | grep -qv 'e+'
+          fi
 
       - name: Package Helm chart
         id: package
         run: |
           mkdir -p dist
           cd ${{ matrix.chart.path }}
+          if [ "${{ matrix.chart.name }}" = "curvine" ]; then
+            helm repo add openkruise https://openkruise.github.io/charts/
+            helm dependency build .
+          fi
           helm package . --destination ../dist
           cd ../dist
           CHART_FILE=$(ls *.tgz)

--- a/curvine-runtime/Chart.lock
+++ b/curvine-runtime/Chart.lock
@@ -1,0 +1,6 @@
+dependencies:
+- name: kruise
+  repository: https://openkruise.github.io/charts/
+  version: 1.9.0
+digest: sha256:6369338e507af7f92e321aa95a585acc8584901e0dfe24f7516c72aca53d1690
+generated: "2026-06-29T16:15:45.601688807+08:00"

--- a/curvine-runtime/Chart.yaml
+++ b/curvine-runtime/Chart.yaml
@@ -16,3 +16,8 @@ maintainers:
   - name: Curvine Team
     email: curvine@example.com
 icon: https://curvineio.github.io/img/curvine_logo.png
+dependencies:
+  - name: kruise
+    version: "1.9.0"
+    repository: "https://openkruise.github.io/charts/"
+    condition: openKruise.enabled

--- a/curvine-runtime/README.md
+++ b/curvine-runtime/README.md
@@ -35,20 +35,24 @@ Confirm these prerequisites first:
   - a default `StorageClass`
   - explicit `storageClass` values in your values file
   - `hostPath` storage on bare metal
-- OpenKruise, if `openKruise.enabled=true`
 - Enough cluster capacity for the requested CPU and memory
 - If you use the production or bare-metal examples:
   - node labels already exist
   - required taints are tolerated
   - privileged Pods and `hostNetwork` are allowed when applicable
 
-### Install OpenKruise
+### OpenKruise (optional)
 
-```bash
-helm repo add openkruise https://openkruise.github.io/charts/
-helm repo update
-helm upgrade --install kruise openkruise/kruise --version 1.9.0
-```
+By default `openKruise.enabled=false`. The chart uses standard `apps/v1` StatefulSets and does not install OpenKruise.
+
+Set `openKruise.enabled=true` when you need:
+
+- Advanced StatefulSet features (in-place image updates)
+- PersistentPodState topology pinning for master pods
+
+Enabling OpenKruise installs the `kruise` subchart (v1.9.0) into `kruise-system` as part of the same `helm upgrade --install` command. Override subchart settings under the top-level `kruise:` values key.
+
+If OpenKruise is already installed cluster-wide, set `openKruise.enabled=true` for Curvine Kruise API usage and consider `kruise.crds.managed=false` to avoid reinstalling CRDs.
 
 The chart defaults are intentionally conservative so a first deployment is less likely to end in `Pending`.
 The chart also includes `values.schema.json` so invalid values can be rejected before rendering.
@@ -128,9 +132,12 @@ helm upgrade --install curvine ./curvine-runtime \
 
 When Master metadata or journal storage uses `hostPath`, the chart treats the
 data as node-local. For multi-Master deployments, it adds required Pod
-anti-affinity and OpenKruise required persistent topology. This keeps each
-Master ordinal on its original node and prevents two Master pods from sharing
-the same node-local RocksDB paths.
+anti-affinity so each Master ordinal stays on a distinct node and two Master
+pods cannot share the same node-local RocksDB paths.
+
+To pin master pods to their original nodes across restarts, set
+`openKruise.enabled=true` and configure `master.persistentTopology` (see the
+bare-metal example).
 
 Master startup is intentionally protected by `master.startupProbe`. A Master
 does not open the RPC port until Raft snapshot restore and metadata tree rebuild
@@ -174,6 +181,18 @@ Use this flow for:
 - config changes
 
 Do not change `master.replicas` during an in-place upgrade.
+
+### Migrating from implicit OpenKruise usage
+
+Older chart versions rendered master StatefulSets as `apps.kruise.io/v1beta1` when
+using `hostPath` storage with `master.persistentTopology.enabled=true`, even if
+`openKruise.enabled=false`. Current versions only use the Kruise API when
+`openKruise.enabled=true`.
+
+If you upgraded from that behavior:
+
+- Set `openKruise.enabled=true` before upgrading to keep Advanced StatefulSet semantics, or
+- Accept that the master StatefulSet apiVersion may change to `apps/v1` and plan accordingly
 
 ### Roll Back
 

--- a/curvine-runtime/examples/values-baremetal.yaml
+++ b/curvine-runtime/examples/values-baremetal.yaml
@@ -8,6 +8,10 @@
 cluster:
   id: "curvine-baremetal"
 
+# Pin master pods to original nodes across restarts (requires Kruise subchart).
+openKruise:
+  enabled: true
+
 master:
   replicas: 3
 

--- a/curvine-runtime/templates/_helpers.tpl
+++ b/curvine-runtime/templates/_helpers.tpl
@@ -351,3 +351,11 @@ Validate master replicas - ensure they cannot be changed on upgrade
 {{- end }}
 {{- end }}
 {{- end }}
+
+{{/*
+Render a TOML integer without scientific notation.
+YAML large integers are parsed as float64 in Helm; printf "%d" after int avoids 1e+06.
+*/}}
+{{- define "curvine.tomlInt" -}}
+{{- printf "%d" (int .) -}}
+{{- end -}}

--- a/curvine-runtime/templates/configmap.yaml
+++ b/curvine-runtime/templates/configmap.yaml
@@ -62,7 +62,7 @@ data:
     rpc_port = {{ .Values.master.journalPort }}
     journal_dir = "{{ $journalDir }}"
     snapshot_interval = {{ .Values.config.journal.snapshotInterval | quote }}
-    snapshot_entries = {{ .Values.config.journal.snapshotEntries }}
+    snapshot_entries = {{ include "curvine.tomlInt" .Values.config.journal.snapshotEntries }}
     {{- if .Values.configOverrides.journal }}
     {{- range $key, $value := .Values.configOverrides.journal }}
     {{ $key }} = {{ toJson $value }}

--- a/curvine-runtime/templates/master-statefulset.yaml
+++ b/curvine-runtime/templates/master-statefulset.yaml
@@ -1,7 +1,5 @@
 {{- include "curvine.validateMasterReplicasOnUpgrade" . }}
-{{- $masterUsesHostPath := eq (include "curvine.masterUsesHostPath" .) "true" }}
-{{- $masterPersistentTopologyEnabled := and $masterUsesHostPath .Values.master.persistentTopology.enabled }}
-{{- $useKruiseStatefulSet := or .Values.openKruise.enabled $masterPersistentTopologyEnabled }}
+{{- $useKruiseStatefulSet := .Values.openKruise.enabled }}
 apiVersion: {{ ternary "apps.kruise.io/v1beta1" "apps/v1" $useKruiseStatefulSet }}
 kind: StatefulSet
 metadata:
@@ -9,14 +7,14 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "curvine.masterLabels" . | nindent 4 }}
-  {{- $generatePersistentPodState := or (and .Values.openKruise.enabled .Values.openKruise.persistentPodState.autoGenerate) $masterPersistentTopologyEnabled }}
+  {{- $generatePersistentPodState := and .Values.openKruise.enabled .Values.openKruise.persistentPodState.autoGenerate }}
   {{- if $generatePersistentPodState }}
   annotations:
     kruise.io/auto-generate-persistent-pod-state: "true"
-    {{- if and (not $masterPersistentTopologyEnabled) .Values.openKruise.persistentPodState.preferredPersistentTopology }}
+    {{- if .Values.openKruise.persistentPodState.preferredPersistentTopology }}
     kruise.io/preferred-persistent-topology: {{ .Values.openKruise.persistentPodState.preferredPersistentTopology | quote }}
     {{- end }}
-    {{- if $masterPersistentTopologyEnabled }}
+    {{- if and .Values.master.persistentTopology.enabled .Values.master.persistentTopology.key }}
     kruise.io/required-persistent-topology: {{ .Values.master.persistentTopology.key | quote }}
     {{- else if .Values.openKruise.persistentPodState.requiredPersistentTopology }}
     kruise.io/required-persistent-topology: {{ .Values.openKruise.persistentPodState.requiredPersistentTopology | quote }}

--- a/curvine-runtime/templates/rbac.yaml
+++ b/curvine-runtime/templates/rbac.yaml
@@ -19,9 +19,11 @@ rules:
   - apiGroups: ["apps"]
     resources: ["statefulsets"]
     verbs: ["get", "list", "watch"]
+  {{- if .Values.openKruise.enabled }}
   - apiGroups: ["apps.kruise.io"]
     resources: ["statefulsets"]
     verbs: ["get", "list", "watch"]
+  {{- end }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding

--- a/curvine-runtime/values.schema.json
+++ b/curvine-runtime/values.schema.json
@@ -355,7 +355,14 @@
           "type": "object"
         },
         "journal": {
-          "type": "object"
+          "type": "object",
+          "properties": {
+            "snapshotEntries": {
+              "type": "integer",
+              "minimum": 1
+            }
+          },
+          "additionalProperties": true
         },
         "worker": {
           "type": "object"

--- a/curvine-runtime/values.yaml
+++ b/curvine-runtime/values.yaml
@@ -19,7 +19,7 @@ image:
 
 # OpenKruise advanced StatefulSet configuration
 openKruise:
-  # Enable OpenKruise Advanced StatefulSet for master/worker
+  # Enable OpenKruise Advanced StatefulSet for master/worker and install the kruise subchart
   enabled: false
   # In-place image update policy: InPlaceOnly | InPlaceIfPossible | ReCreate
   podUpdatePolicy: "InPlaceOnly"
@@ -30,6 +30,12 @@ openKruise:
     preferredPersistentTopology: "kubernetes.io/hostname"
     # Optional strict topology keys, e.g. failure-domain.beta.kubernetes.io/zone
     requiredPersistentTopology: ""
+
+# Kruise subchart values (only installed when openKruise.enabled=true)
+kruise:
+  installation:
+    namespace: kruise-system
+    createNamespace: true
 
 # Master node configuration
 master:


### PR DESCRIPTION
## Summary
- Add conditional `kruise` 1.9.0 Helm subchart (`openKruise.enabled=true`) so OpenKruise installs with the same `helm upgrade --install` command
- Decouple hostPath + `persistentTopology` from implicit Kruise API usage; only `openKruise.enabled=true` renders `apps.kruise.io` StatefulSets and Kruise RBAC
- Fix `snapshot_entries` TOML rendering (`1e+06` → `1000000`) via `curvine.tomlInt` helper so Rust `u64` deserialization succeeds
- Add CI regression checks for integer rendering and `helm dependency build` in release workflow

## Test plan
- [x] `helm lint ./curvine-runtime`
- [x] `helm template test ./curvine-runtime | grep snapshot_entries` → `snapshot_entries = 1000000`
- [x] Default render uses `apps/v1` StatefulSet with no Kruise subchart resources
- [x] `openKruise.enabled=true` renders kruise subchart and Kruise StatefulSets
- [x] `values-baremetal.yaml` with `openKruise.enabled=true` keeps bare-metal topology pinning behavior

## Migration note
Clusters that previously relied on implicit Kruise usage (`hostPath` + `persistentTopology` with `openKruise.enabled=false`) should set `openKruise.enabled=true` before upgrading, or plan for master StatefulSet apiVersion change to `apps/v1`.