### PR TITLE
chore(ci): use fixed 0.0.0-dev chart version for main builds

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -20,7 +20,7 @@ This repository publishes chart packages from source directories and serves the 
 
 ### Push to `main`
 
-- Packages both charts with a fixed `-dev` chart version
+- Packages both charts with a fixed `0.0.0-dev` chart version
 - Updates the GitHub Release named `latest`
 - Does not sync `index.yaml` to `curvine-doc`
 
@@ -42,7 +42,7 @@ Inputs:
 Behavior:
 
 - A tag ref such as `v0.2.0` packages charts with version `0.2.0`
-- A branch ref packages charts as the current base version plus `-dev` and updates the `latest` test release
+- A branch ref packages charts as `0.0.0-dev` and updates the `latest` test release
 - `sync_to_doc=true` is only valid when `ref` is a `v*` tag; the workflow fails fast for branch refs
 - When `sync_to_doc` is enabled for a tag build, the workflow rebuilds `index.yaml` with release URLs and pushes it to `curvine-doc`
 
@@ -50,9 +50,9 @@ Behavior:
 
 | Trigger | Chart Version | App Version | Default Image Tag |
 | --- | --- | --- | --- |
-| `main` push | `<base>-dev` | `latest` | `latest` |
+| `main` push | `0.0.0-dev` | `latest` | `latest` |
 | `v*` tag push | `<tag without v>` | `<tag without v>` | `v<tag without v>` |
-| Manual branch build | `<base>-dev` | `latest` | `latest` |
+| Manual branch build | `0.0.0-dev` | `latest` | `latest` |
 | Manual tag build | `<tag without v>` | `<tag without v>` | `v<tag without v>` |
 
 `values.yaml` leaves `image.tag` empty by default. Templates resolve it to `latest` when

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -122,10 +122,8 @@ jobs:
           CURRENT_VERSION=$(grep '^version:' ${{ matrix.chart.path }}/Chart.yaml | awk '{print $2}' | tr -d '"')
           echo "Current Chart version for ${{ matrix.chart.name }}: $CURRENT_VERSION"
 
-          BASE_VERSION=$(echo "$CURRENT_VERSION" | sed 's/-.*//')
-          echo "Base version: $BASE_VERSION"
           if [ "${{ steps.tag.outputs.is_branch_build }}" == "true" ]; then
-            FINAL_VERSION="${BASE_VERSION}-dev"
+            FINAL_VERSION="0.0.0-dev"
             APP_VERSION="latest"
           else
             FINAL_VERSION="${{ steps.tag.outputs.version }}"
@@ -135,6 +133,7 @@ jobs:
           sed -i "s/^version:.*/version: $FINAL_VERSION/" ${{ matrix.chart.path }}/Chart.yaml
           sed -i "s/^appVersion:.*/appVersion: \"$APP_VERSION\"/" ${{ matrix.chart.path }}/Chart.yaml
           echo "version=$FINAL_VERSION" >> $GITHUB_OUTPUT
+          echo "app_version=$APP_VERSION" >> $GITHUB_OUTPUT
           echo "Updated Chart.yaml version to: $FINAL_VERSION, appVersion to: $APP_VERSION"
           cat ${{ matrix.chart.path }}/Chart.yaml
 
@@ -186,8 +185,9 @@ jobs:
         run: |
           echo "## Build Summary - ${{ matrix.chart.name }}" >> $GITHUB_STEP_SUMMARY
           echo "- **Chart**: ${{ matrix.chart.name }}" >> $GITHUB_STEP_SUMMARY
-          echo "- **Tag/Version**: ${{ steps.tag.outputs.tag }}" >> $GITHUB_STEP_SUMMARY
+          echo "- **Release Tag**: ${{ steps.tag.outputs.tag }}" >> $GITHUB_STEP_SUMMARY
           echo "- **Chart Version**: ${{ steps.version.outputs.version }}" >> $GITHUB_STEP_SUMMARY
+          echo "- **App Version**: ${{ steps.version.outputs.app_version }}" >> $GITHUB_STEP_SUMMARY
           echo "- **Chart Package**: ${{ steps.package.outputs.chart_name }}" >> $GITHUB_STEP_SUMMARY
           echo "- **Digest (SHA256)**: ${{ steps.checksum.outputs.digest }}" >> $GITHUB_STEP_SUMMARY
 
@@ -378,8 +378,8 @@ jobs:
             ```
             
             ### Files
-            - curvine-csi chart package (version: *-dev)
-            - curvine chart package (version: *-dev)
+            - curvine-csi chart package (version: 0.0.0-dev)
+            - curvine chart package (version: 0.0.0-dev)
             - checksums.txt (SHA256 checksums for both charts)
             
             > **Note**: This release is automatically overwritten. Do not use in production!

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ every release.
 | Curvine git tag | `v0.3.0` | — | `CurvineIO/curvine` | Application release tag |
 | Container image tag | `v0.3.0` | `latest` | `ghcr.io/curvineio/curvine`, `ghcr.io/curvineio/curvine-csi` | Image pulled by workloads |
 | Helm git tag | `v0.3.0` | — | `CurvineIO/curvine-helm` | Chart release tag in this repository |
-| `Chart.version` | `0.3.0` | `0.2.0-dev` | `Chart.yaml` | Helm chart package version |
+| `Chart.version` | `0.3.0` | `0.0.0-dev` | `Chart.yaml` | Helm chart package version |
 | `Chart.appVersion` | `0.3.0` | `latest` | `Chart.yaml` | Application version deployed by the chart |
 | `values.image.tag` | `""` | `""` | `values.yaml` | Optional image tag override |
 
@@ -105,7 +105,7 @@ flowchart LR
 
 ```mermaid
 flowchart LR
-  M["push to main"] --> CV["Chart.version<br/>0.2.0-dev"]
+  M["push to main"] --> CV["Chart.version<br/>0.0.0-dev"]
   M --> AV["Chart.appVersion<br/>latest"]
   AV --> IT["default image tag<br/>latest"]
   IMG["container image<br/>latest"] -. rolling image .- IT
@@ -121,7 +121,7 @@ Rules:
    resolve it to `latest` when `Chart.AppVersion` is `latest`, otherwise `v{Chart.AppVersion}`
    (for example `0.3.0` becomes `v0.3.0`).
 4. **`Chart.version` and `Chart.appVersion` usually match** for versioned releases. For `main`
-   branch test packages, `Chart.version` stays `<base>-dev` while `appVersion` is `latest`.
+   branch test packages, `Chart.version` is fixed at `0.0.0-dev` while `appVersion` is `latest`.
 5. **Override when needed.** Use `--set image.tag=...` for custom images, hotfixes, or pinned builds.
 
 ### Release Mapping
@@ -129,10 +129,10 @@ Rules:
 | Trigger in `curvine-helm` | `Chart.version` | `Chart.appVersion` | Default `image.tag` |
 | --- | --- | --- | --- |
 | Push `v0.3.0` tag | `0.3.0` | `0.3.0` | `v0.3.0` |
-| Push to `main` | `<base>-dev` | `latest` | `latest` |
+| Push to `main` | `0.0.0-dev` | `latest` | `latest` |
 
 `main` branch test packages use rolling `latest` images from the registry. The chart package
-version remains `<base>-dev` so it does not collide with versioned releases.
+version is fixed at `0.0.0-dev` so it does not collide with versioned releases.
 
 ### Example: Versioned Release
 
@@ -160,13 +160,13 @@ helm upgrade --install curvine curvineio/curvine --version 0.3.0 -n curvine --cr
 ```bash
 # 1. Merge chart changes to main
 #    GitHub Actions packages charts into the `latest` test release:
-#    chart package version: 0.2.0-dev
+#    chart package version: 0.0.0-dev
 #    chart appVersion: latest
 #    rendered image: ghcr.io/curvineio/curvine:latest
 
 # 2. Install the rolling test package from GitHub Releases
-wget https://github.com/CurvineIO/curvine-helm/releases/download/latest/curvine-0.2.0-dev.tgz
-helm upgrade --install curvine ./curvine-0.2.0-dev.tgz -n curvine --create-namespace
+wget https://github.com/CurvineIO/curvine-helm/releases/download/latest/curvine-0.0.0-dev.tgz
+helm upgrade --install curvine ./curvine-0.0.0-dev.tgz -n curvine --create-namespace
 ```
 
 Use this flow for chart development and integration testing only. For production, install a

--- a/curvine-csi/README.md
+++ b/curvine-csi/README.md
@@ -20,7 +20,7 @@ from `Chart.appVersion`:
 | `latest` | `latest` |
 
 On versioned releases, `Chart.version` and `Chart.appVersion` match. On `main` branch test
-packages, `Chart.version` is `<base>-dev` while `appVersion` is `latest`.
+packages, `Chart.version` is `0.0.0-dev` while `appVersion` is `latest`.
 
 See the repository [README](../README.md#versioning-model) for the full version mapping and
 release workflow.

--- a/curvine-runtime/README.md
+++ b/curvine-runtime/README.md
@@ -22,7 +22,7 @@ from `Chart.appVersion`:
 | `latest` | `latest` |
 
 On versioned releases, `Chart.version` and `Chart.appVersion` match. On `main` branch test
-packages, `Chart.version` is `<base>-dev` while `appVersion` is `latest`.
+packages, `Chart.version` is `0.0.0-dev` while `appVersion` is `latest`.
 
 See the repository [README](../README.md#versioning-model) for the full version mapping and
 release workflow.


### PR DESCRIPTION
## Summary
- Pin `Chart.version` to `0.0.0-dev` for `main` and manual branch builds instead of deriving `<base>-dev` from `Chart.yaml`
- Keep `Chart.appVersion` as `latest` for branch builds; versioned `v*` tag builds still derive both fields from the tag
- Improve Build Summary with `Release Tag`, `Chart Version`, and `App Version`
- Update repository and workflow README versioning docs/examples

## Test plan
- [ ] Push to `main` and verify packaged charts are `*-0.0.0-dev.tgz` with `appVersion: latest`
- [ ] Verify `helm search` shows `0.0.0-dev` / `latest` for test packages
- [ ] Push `v*` tag and verify chart metadata still uses the tag version (e.g. `0.3.0`)