### PR TITLE
feat(ci): auto-sync helm index to curvine-doc on main push

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -22,7 +22,7 @@ This repository publishes chart packages from source directories and serves the 
 
 - Packages both charts with a fixed `0.0.0-dev` chart version
 - Updates the GitHub Release named `latest`
-- Does not sync `index.yaml` to `curvine-doc`
+- Syncs `index.yaml` to `curvine-doc` automatically
 
 Use this for testing only.
 
@@ -30,21 +30,20 @@ Use this for testing only.
 
 - Packages both charts with the tag version
 - Creates or updates the matching GitHub Release
-- Does not sync `index.yaml` automatically
+- Syncs `index.yaml` to `curvine-doc` automatically
 
 ### Manual trigger
 
 Inputs:
 
 - `ref`: branch or tag to build
-- `sync_to_doc`: whether to sync the public `index.yaml` to `curvine-doc` for a version tag build
+- `sync_to_doc`: whether to sync the public `index.yaml` to `curvine-doc` after a manual build
 
 Behavior:
 
 - A tag ref such as `v0.2.0` packages charts with version `0.2.0`
 - A branch ref packages charts as `0.0.0-dev` and updates the `latest` test release
-- `sync_to_doc=true` is only valid when `ref` is a `v*` tag; the workflow fails fast for branch refs
-- When `sync_to_doc` is enabled for a tag build, the workflow rebuilds `index.yaml` with release URLs and pushes it to `curvine-doc`
+- When `sync_to_doc` is enabled, the workflow rebuilds `index.yaml` with release URLs and pushes it to `curvine-doc`
 
 ## Versioning Rules
 
@@ -73,13 +72,11 @@ helm upgrade --install curvine-csi curvineio/curvine-csi
 ## Release Checklist
 
 1. Update chart source and documentation.
-2. Push to `main` if you need a test package in the `latest` release.
-3. Create and push a `v*` tag for a versioned release.
-4. Manually run the workflow with `ref=<v-tag>` and `sync_to_doc=true` when you are ready to publish the updated index.
+2. Push to `main` to publish a `0.0.0-dev` test package to the `latest` release and sync the public index.
+3. Create and push a `v*` tag for a versioned release; the public index syncs automatically.
 
 ## Notes
 
 - The runtime source directory is `curvine-runtime/`, but the published chart name is `curvine`.
 - The public repository URL should always point to `curvine-doc`.
 - GitHub Releases are the source of truth for chart package files.
-- Manual branch builds are for release validation only and must not be synced into the public Helm index.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -409,8 +409,8 @@ jobs:
     needs:
       - validate-inputs
       - create-release
-    # Auto-sync on v* tag push; manual workflow_dispatch via sync_to_doc
-    if: always() && needs.create-release.result == 'success' && ((github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')) || (github.event_name == 'workflow_dispatch' && inputs.sync_to_doc == true))
+    # Auto-sync on main or v* tag push; manual workflow_dispatch via sync_to_doc
+    if: always() && needs.create-release.result == 'success' && ((github.event_name == 'push' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v'))) || (github.event_name == 'workflow_dispatch' && inputs.sync_to_doc == true))
     runs-on: ubuntu-latest
     permissions:
       contents: write


### PR DESCRIPTION
## Summary
- Run `sync-to-helm-repo` automatically after successful `main` branch pushes
- Keep existing auto-sync on `v*` tag push and manual `sync_to_doc=true` workflow_dispatch
- Update workflow README to reflect automatic index sync for both `main` and `v*` releases

## Test plan
- [ ] Merge to `main` and verify `sync-to-helm-repo` runs after `create-release`
- [ ] Confirm `curvine-doc/static/helm-charts/index.yaml` includes `0.0.0-dev` entries pointing to the `latest` release
- [ ] Push a `v*` tag and verify versioned release sync still works