### PR TITLE
fix(ci): clean latest release chart assets before upload

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -21,6 +21,7 @@ This repository publishes chart packages from source directories and serves the 
 ### Push to `main`
 
 - Packages both charts with a fixed `0.0.0-dev` chart version
+- Deletes existing `*.tgz` and `checksums.txt` assets from the `latest` release before upload
 - Updates the GitHub Release named `latest`
 - Syncs `index.yaml` to `curvine-doc` automatically
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -299,6 +299,34 @@ jobs:
           echo "Release Type: $RELEASE_TYPE"
           echo "Release Tag: $RELEASE_TAG"
 
+      - name: Clean stale assets from latest release
+        if: steps.release.outputs.release_type == 'latest'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+
+          if ! gh release view latest --repo "${GITHUB_REPOSITORY}" >/dev/null 2>&1; then
+            echo "No existing latest release; skip asset cleanup."
+            exit 0
+          fi
+
+          mapfile -t asset_ids < <(
+            gh release view latest --repo "${GITHUB_REPOSITORY}" \
+              --json assets \
+              --jq '.assets[] | select(.name | test("\\.tgz$|^checksums\\.txt$")) | .id'
+          )
+
+          if [ "${#asset_ids[@]}" -eq 0 ]; then
+            echo "No chart assets to delete on latest release."
+            exit 0
+          fi
+
+          for asset_id in "${asset_ids[@]}"; do
+            echo "Deleting release asset id: ${asset_id}"
+            gh api --method DELETE "repos/${GITHUB_REPOSITORY}/releases/assets/${asset_id}"
+          done
+
       - name: Create/Update GitHub Release (v* tag)
         if: steps.release.outputs.release_type == 'tag'
         uses: softprops/action-gh-release@v2


### PR DESCRIPTION
## Summary
- Before updating the `latest` testing release, delete all existing `*.tgz` and `checksums.txt` assets
- Prevents stale chart packages (e.g. `0.2.0-dev`) from remaining alongside `0.0.0-dev`
- Document the cleanup behavior in the workflow README

## Why
`softprops/action-gh-release` only overwrites assets with the **same filename**. When chart version naming changed from `<base>-dev` to `0.0.0-dev`, old `*-0.2.0-dev.tgz` files were left behind and later re-indexed during sync.

For steady-state `0.0.0-dev` builds, same-name files would be overwritten, but explicit cleanup still keeps the `latest` release and sync input set minimal and predictable.

## Test plan
- [ ] Push to `main` and verify the workflow deletes old `latest` assets before upload
- [ ] Confirm `latest` release contains only the two current `0.0.0-dev` charts plus `checksums.txt`
- [ ] Confirm sync no longer downloads stale `0.2.0-dev` packages