### PR TITLE
fix(ci): merge helm index from curvine-doc git instead of Pages

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -14,6 +14,7 @@ This repository publishes chart packages from source directories and serves the 
 - Chart source code lives in this repository.
 - Packaged charts are uploaded to GitHub Releases.
 - The public Helm index lives at `https://curvineio.github.io/curvine-doc/helm-charts/index.yaml`.
+- Sync reads the existing index from the `curvine-doc` git repository and merges new chart versions into it.
 - The workflow does not commit packaged charts or `index.yaml` back into this repository.
 
 ## Triggers

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -492,24 +492,24 @@ jobs:
         with:
           version: 'latest'
 
-      - name: Download old index.yaml from curvine-doc
+      - name: Prepare existing index.yaml for merge
         run: |
           mkdir -p temp-charts
-          cd temp-charts
-          
-          # Try to download existing index.yaml
-          echo "Downloading existing index.yaml from curvine-doc..."
-          curl -fsSL https://curvineio.github.io/curvine-doc/helm-charts/index.yaml -o old-index.yaml || {
-            echo "No existing index.yaml found, will create new one"
-            touch old-index.yaml
-          }
-          
-          if [ -s old-index.yaml ]; then
-            echo "Existing index.yaml found:"
-            head -20 old-index.yaml
-          else
-            echo "Creating new index.yaml"
+          INDEX_PATH="curvine-doc/static/helm-charts/index.yaml"
+
+          if [ ! -f "$INDEX_PATH" ]; then
+            echo "::error title=Missing index.yaml::Expected $INDEX_PATH in curvine-doc. Bootstrap the public Helm index in curvine-doc before syncing releases."
+            exit 1
           fi
+
+          if [ ! -s "$INDEX_PATH" ]; then
+            echo "::error title=Empty index.yaml::$INDEX_PATH is empty. Refusing to regenerate the public index without merge input."
+            exit 1
+          fi
+
+          cp "$INDEX_PATH" temp-charts/old-index.yaml
+          echo "Loaded existing index.yaml from curvine-doc git repository:"
+          head -20 temp-charts/old-index.yaml
 
       - name: Download current release charts
         run: |
@@ -534,19 +534,10 @@ jobs:
           
           RELEASE_TAG="${{ steps.source.outputs.tag }}"
           
-          # Check if old-index.yaml exists and is not empty
-          if [ -s old-index.yaml ]; then
-            echo "Merging with existing index.yaml..."
-            # Generate index.yaml with Release URLs and merge with old index
-            helm repo index . \
-              --url "https://github.com/CurvineIO/curvine-helm/releases/download/${RELEASE_TAG}" \
-              --merge old-index.yaml
-          else
-            echo "Creating new index.yaml (no existing index found)..."
-            # Generate new index.yaml without merging
-            helm repo index . \
-              --url "https://github.com/CurvineIO/curvine-helm/releases/download/${RELEASE_TAG}"
-          fi
+          echo "Merging new charts into existing index.yaml..."
+          helm repo index . \
+            --url "https://github.com/CurvineIO/curvine-helm/releases/download/${RELEASE_TAG}" \
+            --merge old-index.yaml
           
           echo "Generated index.yaml (first 100 lines):"
           head -100 index.yaml


### PR DESCRIPTION
## Summary
- Load `old-index.yaml` from the checked-out `curvine-doc` git repository instead of `curvineio.github.io`
- Fail the sync job when the index file is missing or empty instead of creating a fresh index
- Always run `helm repo index --merge` so tagged releases accumulate alongside existing versions

## Why
`v0.3.1-alpha` sync downloaded the old index from GitHub Pages, `curl` failed, and the workflow fell back to an empty file. That regenerated an index containing only `0.3.1-alpha` and removed `0.0.0-dev` from the public repo.

## Test plan
- [ ] Push a `v*` tag and verify sync merges with the existing `curvine-doc/static/helm-charts/index.yaml`
- [ ] Confirm `0.0.0-dev` remains listed after a tagged release sync
- [ ] Verify sync fails clearly if `index.yaml` is missing or empty