### PR TITLE
fix(curvine-csi): use registry.k8s.io for CSI sidecar images

### DIFF
--- a/curvine-csi/README.md
+++ b/curvine-csi/README.md
@@ -61,7 +61,7 @@ helm upgrade --install curvine-csi ./curvine-csi \
 - You can override them with:
   - `serviceAccount.controller.name`
   - `serviceAccount.node.name`
-- Standalone mount mode is enabled by default through `node.mountMode=standalone`.
+- Embedded mount mode is the default through `node.mountMode=embedded`.
 
 ## Core Values
 
@@ -71,7 +71,7 @@ helm upgrade --install curvine-csi ./curvine-csi \
 | `image.tag` | CSI image tag (empty uses `latest` when `Chart.AppVersion` is `latest`, otherwise `v{Chart.AppVersion}`) | `""` |
 | `csiDriver.name` | CSI driver name | `curvine` |
 | `controller.replicas` | Controller replica count | `1` |
-| `node.mountMode` | FUSE mount strategy | `standalone` |
+| `node.mountMode` | FUSE mount strategy | `embedded` |
 | `node.priorityClassName` | Node DaemonSet priority class | `system-node-critical` |
 | `rbac.create` | Create service accounts, cluster roles, and bindings | `true` |
 

--- a/curvine-csi/values.yaml
+++ b/curvine-csi/values.yaml
@@ -54,7 +54,7 @@ controller:
   # Sidecar containers
   sidecars:
     provisioner:
-      image: quay.io/k8scsi/csi-provisioner:v1.6.0
+      image: registry.k8s.io/sig-storage/csi-provisioner:v5.0.1
       args:
         - --csi-address=$(ADDRESS)
         - --timeout=60s
@@ -155,7 +155,7 @@ node:
   # Sidecar containers
   sidecars:
     nodeDriverRegistrar:
-      image: quay.io/k8scsi/csi-node-driver-registrar:v2.1.0
+      image: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.13.0
       args:
         - --csi-address=$(ADDRESS)
         - --kubelet-registration-path=$(DRIVER_REG_SOCK_PATH)


### PR DESCRIPTION
## Problem
Default CSI sidecar images point to deprecated `quay.io/k8scsi/*` repositories, causing ImagePullBackOff on fresh installs.

## Design
Switch provisioner and node-driver-registrar defaults to the official `registry.k8s.io/sig-storage` images. Update README mount mode defaults to match `values.yaml`.

## Key Changes
- `csi-provisioner`: `registry.k8s.io/sig-storage/csi-provisioner:v5.0.1`
- `csi-node-driver-registrar`: `registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.13.0`
- README: document `embedded` as the default mount mode