### PR TITLE
feat(runtime): deploy standalone transfer service (#1040)

### DIFF
--- a/curvine-runtime/README.md
+++ b/curvine-runtime/README.md
@@ -159,15 +159,23 @@ transfer:
   enabled: true
   storeUrl: ""
   replicas: 1
+  storage:
+    size: "1Gi"
   rpcPort: 9010
   webPort: 9011
 ```
 
 An empty `storeUrl` keeps Curvine's default single-instance SQLite store at
-`/app/curvine/data/transfer/transfer.db`. Its `emptyDir` survives a container
-restart in the same Pod but is not durable across Pod replacement. Use a MySQL
-URL for durable production operation. Multiple Transfer replicas require a
-shared MySQL store and the chart rejects other configurations:
+`/app/curvine/data/transfer/transfer.db`. The chart creates a `ReadWriteOnce`
+PVC and mounts it at that directory. It omits `storageClassName`, so Kubernetes
+uses the cluster default StorageClass. A cluster without a default StorageClass
+leaves the PVC Pending instead of silently using temporary storage. Multiple
+Transfer replicas require a shared MySQL store and the chart rejects other
+configurations:
+
+The SQLite Deployment uses `Recreate` to detach its `ReadWriteOnce` volume
+before a replacement Pod starts. Its PVC is retained by `helm uninstall`; delete
+it explicitly only when discarding the Transfer metadata.
 
 ```yaml
 transfer:
@@ -196,6 +204,7 @@ configOverrides:
 | --- | --- | --- |
 | `enabled` | `transfer.enabled` | `false`; creates no Transfer workload until enabled. |
 | `store_url` | `transfer.storeUrl` | Empty infers `sqlite://data/transfer/transfer.db`. |
+| SQLite PVC capacity | `transfer.storage.size` | `1Gi`; created only when `storeUrl` is empty and uses the default StorageClass. |
 | `hostname` | Generated | The internal Transfer Service DNS. |
 | `rpc_port` | `transfer.rpcPort` | `9010`. |
 | `web_port` | `transfer.webPort` | `9011`. |

--- a/curvine-runtime/README.md
+++ b/curvine-runtime/README.md
@@ -147,6 +147,74 @@ can become ready.
 
 Do not use the production or bare-metal examples unchanged on a generic cluster. Edit storage classes, labels, and paths first.
 
+## Transfer Service
+
+Set `transfer.enabled=true` to deploy the standalone Transfer service. The chart
+creates an internal `ClusterIP` service and writes its Kubernetes DNS name into
+`[transfer].hostname`; Curvine then infers the client and Worker RPC endpoint.
+No `transfer.endpoints` value is required.
+
+```yaml
+transfer:
+  enabled: true
+  storeUrl: ""
+  replicas: 1
+  rpcPort: 9010
+  webPort: 9011
+```
+
+An empty `storeUrl` keeps Curvine's default single-instance SQLite store at
+`/app/curvine/data/transfer/transfer.db`. Its `emptyDir` survives a container
+restart in the same Pod but is not durable across Pod replacement. Use a MySQL
+URL for durable production operation. Multiple Transfer replicas require a
+shared MySQL store and the chart rejects other configurations:
+
+```yaml
+transfer:
+  enabled: true
+  storeUrl: "mysql://<user>:<password>@mysql.example:3306/curvine_transfer"
+  replicas: 2
+```
+
+`transfer.enabled`/`storeUrl`/`replicas`/`rpcPort`/`webPort` are chart-managed:
+the generated Service, Deployment and `[transfer]` configuration always use the
+same values. The hostname is always the generated Kubernetes Service DNS. Do
+not set these keys under `configOverrides.transfer`.
+
+All other supported `[transfer]` settings use the existing pass-through map:
+
+```yaml
+configOverrides:
+  transfer:
+    max_running_transfers: 128
+    lease_timeout: "180s"
+    terminal_retention: "336h"
+    cv_metadata_reader: "replica"
+```
+
+| `[transfer]` parameter | Helm setting | Default and behavior |
+| --- | --- | --- |
+| `enabled` | `transfer.enabled` | `false`; creates no Transfer workload until enabled. |
+| `store_url` | `transfer.storeUrl` | Empty infers `sqlite://data/transfer/transfer.db`. |
+| `hostname` | Generated | The internal Transfer Service DNS. |
+| `rpc_port` | `transfer.rpcPort` | `9010`. |
+| `web_port` | `transfer.webPort` | `9011`. |
+| `instance_id` | `configOverrides.transfer.instance_id` | Empty generates a unique instance ID. |
+| `endpoints` | `configOverrides.transfer.endpoints` | Empty infers the generated Service DNS and RPC port. |
+| `cv_metadata_reader` | `configOverrides.transfer.cv_metadata_reader` | `auto`, which resolves to `replica`. |
+| `max_running_transfers` | `configOverrides.transfer.max_running_transfers` | `64`. |
+| `lease_timeout` | `configOverrides.transfer.lease_timeout` | `120s`. |
+| `terminal_retention` | `configOverrides.transfer.terminal_retention` | `168h`. |
+
+The pass-through also accepts the deprecated compatibility keys `store_type`,
+`sqlite_path`, and `mysql_url`; use `storeUrl` instead. Fields that the server
+marks as internal or derived are not configuration options in any deployment
+mode.
+
+The Transfer web endpoint exposes `/healthz`, `/readyz`, and `/metrics` on
+`transfer.webPort`. The RPC service listens on `transfer.rpcPort` inside the
+cluster.
+
 ## Verify
 
 Run these commands immediately after install or upgrade:

--- a/curvine-runtime/templates/NOTES.txt
+++ b/curvine-runtime/templates/NOTES.txt
@@ -19,6 +19,11 @@ If a Pod is Pending:
 Access the master web UI:
   kubectl port-forward -n {{ .Release.Namespace }} svc/{{ include "curvine.masterServiceName" . }} {{ .Values.master.webPort }}:{{ .Values.master.webPort }}
 
+{{- if .Values.transfer.enabled }}
+Access the Transfer health and metrics endpoint:
+  kubectl port-forward -n {{ .Release.Namespace }} svc/{{ include "curvine.transferServiceName" . }} {{ .Values.transfer.webPort }}:{{ .Values.transfer.webPort }}
+{{- end }}
+
 Upgrade in place:
   helm upgrade --install {{ .Release.Name }} <chart-ref> -n {{ .Release.Namespace }} -f values.yaml
 

--- a/curvine-runtime/templates/_helpers.tpl
+++ b/curvine-runtime/templates/_helpers.tpl
@@ -132,6 +132,13 @@ Transfer service name
 {{- end }}
 
 {{/*
+Transfer SQLite PVC name
+*/}}
+{{- define "curvine.transferDataClaimName" -}}
+{{- printf "%s-transfer-data" (include "curvine.fullname" .) | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
 Extract S3 gateway port from listen address
 */}}
 {{- define "curvine.s3GatewayPort" -}}

--- a/curvine-runtime/templates/_helpers.tpl
+++ b/curvine-runtime/templates/_helpers.tpl
@@ -81,6 +81,22 @@ app.kubernetes.io/component: worker
 {{- end }}
 
 {{/*
+Transfer specific labels
+*/}}
+{{- define "curvine.transferLabels" -}}
+{{ include "curvine.labels" . }}
+app.kubernetes.io/component: transfer
+{{- end }}
+
+{{/*
+Transfer selector labels
+*/}}
+{{- define "curvine.transferSelectorLabels" -}}
+{{ include "curvine.selectorLabels" . }}
+app.kubernetes.io/component: transfer
+{{- end }}
+
+{{/*
 Master fullname
 */}}
 {{- define "curvine.masterFullname" -}}
@@ -109,6 +125,13 @@ Worker service name (headless)
 {{- end }}
 
 {{/*
+Transfer service name
+*/}}
+{{- define "curvine.transferServiceName" -}}
+{{- printf "%s-transfer" (include "curvine.fullname" .) | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
 Extract S3 gateway port from listen address
 */}}
 {{- define "curvine.s3GatewayPort" -}}
@@ -132,6 +155,15 @@ Validate master replicas is odd number
 {{- define "curvine.validateMasterReplicas" -}}
 {{- if not (mod (int .Values.master.replicas) 2) }}
 {{- fail "master.replicas must be an odd number (1, 3, 5, 7...) for Raft consensus" }}
+{{- end }}
+{{- end }}
+
+{{/*
+Multiple Transfer instances need a shared, transactional metadata store.
+*/}}
+{{- define "curvine.validateTransfer" -}}
+{{- if and .Values.transfer.enabled (gt (int .Values.transfer.replicas) 1) (not (hasPrefix "mysql://" .Values.transfer.storeUrl)) }}
+{{- fail "transfer.replicas > 1 requires transfer.storeUrl to use mysql://" }}
 {{- end }}
 {{- end }}
 

--- a/curvine-runtime/templates/configmap.yaml
+++ b/curvine-runtime/templates/configmap.yaml
@@ -1,4 +1,5 @@
 {{- include "curvine.validateMasterReplicas" . }}
+{{- include "curvine.validateTransfer" . }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -143,6 +144,24 @@ data:
     [[client.master_addrs]]
     hostname = "{{ include "curvine.masterFullname" $ }}-{{ $i }}.{{ include "curvine.masterServiceName" $ }}.{{ $.Release.Namespace }}.svc.{{ $.Values.global.clusterDomain }}"
     port = {{ $.Values.master.rpcPort }}
+    {{- end }}
+
+    [transfer]
+    enabled = {{ .Values.transfer.enabled }}
+    hostname = "{{ include "curvine.transferServiceName" . }}.{{ .Release.Namespace }}.svc.{{ .Values.global.clusterDomain }}"
+    rpc_port = {{ .Values.transfer.rpcPort }}
+    web_port = {{ .Values.transfer.webPort }}
+    {{- with .Values.transfer.storeUrl }}
+    store_url = {{ . | quote }}
+    {{- end }}
+    {{- $managedTransferKeys := list "enabled" "hostname" "rpc_port" "web_port" "store_url" }}
+    {{- if .Values.configOverrides.transfer }}
+    {{- range $key, $value := .Values.configOverrides.transfer }}
+    {{- if has $key $managedTransferKeys }}
+    {{- fail (printf "configOverrides.transfer.%s is managed by the transfer section" $key) }}
+    {{- end }}
+    {{ $key }} = {{ toJson $value }}
+    {{- end }}
     {{- end }}
 
     [log]

--- a/curvine-runtime/templates/transfer-deployment.yaml
+++ b/curvine-runtime/templates/transfer-deployment.yaml
@@ -1,0 +1,83 @@
+{{- if .Values.transfer.enabled }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "curvine.transferServiceName" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "curvine.transferLabels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.transfer.replicas }}
+  selector:
+    matchLabels:
+      {{- include "curvine.transferSelectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "curvine.transferSelectorLabels" . | nindent 8 }}
+      annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+    spec:
+      serviceAccountName: {{ include "curvine.serviceAccountName" . }}
+      {{- include "curvine.imagePullSecrets" . | nindent 6 }}
+      containers:
+        - name: transfer
+          image: {{ include "curvine.image" . }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          command:
+            - /entrypoint.sh
+          args:
+            - transfer
+            - start
+          env:
+            - name: APP_HOME
+              value: {{ include "curvine.appHome" . | quote }}
+            - name: CURVINE_HOME
+              value: {{ include "curvine.home" . | quote }}
+            - name: CURVINE_CONF_FILE
+              value: {{ include "curvine.configFile" . | quote }}
+            - name: ORPC_BIND_HOSTNAME
+              value: "0.0.0.0"
+          ports:
+            - name: rpc
+              containerPort: {{ .Values.transfer.rpcPort }}
+              protocol: TCP
+            - name: web
+              containerPort: {{ .Values.transfer.webPort }}
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: web
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            timeoutSeconds: 3
+            failureThreshold: 3
+          readinessProbe:
+            httpGet:
+              path: /readyz
+              port: web
+            initialDelaySeconds: 5
+            periodSeconds: 5
+            timeoutSeconds: 3
+            failureThreshold: 3
+          resources:
+            {{- toYaml .Values.transfer.resources | nindent 12 }}
+          volumeMounts:
+            - name: config
+              mountPath: {{ include "curvine.configFile" . }}
+              subPath: curvine-cluster.toml
+              readOnly: true
+            - name: logs
+              mountPath: {{ .Values.config.log.logDir }}
+            - name: transfer-data
+              mountPath: {{ include "curvine.home" . }}/data/transfer
+      volumes:
+        - name: config
+          configMap:
+            name: {{ include "curvine.fullname" . }}-config
+        - name: logs
+          emptyDir: {}
+        - name: transfer-data
+          emptyDir: {}
+{{- end }}

--- a/curvine-runtime/templates/transfer-deployment.yaml
+++ b/curvine-runtime/templates/transfer-deployment.yaml
@@ -8,6 +8,11 @@ metadata:
     {{- include "curvine.transferLabels" . | nindent 4 }}
 spec:
   replicas: {{ .Values.transfer.replicas }}
+  {{- if not .Values.transfer.storeUrl }}
+  # SQLite uses one ReadWriteOnce PVC, so terminate the old Pod before replacement.
+  strategy:
+    type: Recreate
+  {{- end }}
   selector:
     matchLabels:
       {{- include "curvine.transferSelectorLabels" . | nindent 6 }}
@@ -70,14 +75,19 @@ spec:
               readOnly: true
             - name: logs
               mountPath: {{ .Values.config.log.logDir }}
+            {{- if not .Values.transfer.storeUrl }}
             - name: transfer-data
               mountPath: {{ include "curvine.home" . }}/data/transfer
+            {{- end }}
       volumes:
         - name: config
           configMap:
             name: {{ include "curvine.fullname" . }}-config
         - name: logs
           emptyDir: {}
+        {{- if not .Values.transfer.storeUrl }}
         - name: transfer-data
-          emptyDir: {}
+          persistentVolumeClaim:
+            claimName: {{ include "curvine.transferDataClaimName" . }}
+        {{- end }}
 {{- end }}

--- a/curvine-runtime/templates/transfer-pvc.yaml
+++ b/curvine-runtime/templates/transfer-pvc.yaml
@@ -1,0 +1,17 @@
+{{- if and .Values.transfer.enabled (not .Values.transfer.storeUrl) }}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "curvine.transferDataClaimName" . }}
+  namespace: {{ .Release.Namespace }}
+  annotations:
+    helm.sh/resource-policy: keep
+  labels:
+    {{- include "curvine.transferLabels" . | nindent 4 }}
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: {{ .Values.transfer.storage.size }}
+{{- end }}

--- a/curvine-runtime/templates/transfer-service.yaml
+++ b/curvine-runtime/templates/transfer-service.yaml
@@ -1,0 +1,22 @@
+{{- if .Values.transfer.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "curvine.transferServiceName" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "curvine.transferLabels" . | nindent 4 }}
+spec:
+  type: ClusterIP
+  ports:
+    - name: rpc
+      port: {{ .Values.transfer.rpcPort }}
+      targetPort: {{ .Values.transfer.rpcPort }}
+      protocol: TCP
+    - name: web
+      port: {{ .Values.transfer.webPort }}
+      targetPort: {{ .Values.transfer.webPort }}
+      protocol: TCP
+  selector:
+    {{- include "curvine.transferSelectorLabels" . | nindent 4 }}
+{{- end }}

--- a/curvine-runtime/values.schema.json
+++ b/curvine-runtime/values.schema.json
@@ -303,6 +303,16 @@
           "minimum": 1,
           "maximum": 65535
         },
+        "storage": {
+          "type": "object",
+          "properties": {
+            "size": {
+              "type": "string",
+              "minLength": 1
+            }
+          },
+          "additionalProperties": true
+        },
         "resources": {
           "$ref": "#/definitions/resources"
         }

--- a/curvine-runtime/values.schema.json
+++ b/curvine-runtime/values.schema.json
@@ -280,6 +280,35 @@
       },
       "additionalProperties": true
     },
+    "transfer": {
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "type": "boolean"
+        },
+        "storeUrl": {
+          "type": "string"
+        },
+        "replicas": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "rpcPort": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 65535
+        },
+        "webPort": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 65535
+        },
+        "resources": {
+          "$ref": "#/definitions/resources"
+        }
+      },
+      "additionalProperties": true
+    },
     "service": {
       "type": "object",
       "properties": {
@@ -402,6 +431,9 @@
           "type": "object"
         },
         "client": {
+          "type": "object"
+        },
+        "transfer": {
           "type": "object"
         },
         "log": {

--- a/curvine-runtime/values.yaml
+++ b/curvine-runtime/values.yaml
@@ -235,11 +235,16 @@ worker:
 # Disabled by default to preserve existing Master and Worker deployments.
 transfer:
   enabled: false
-  # SQLite is inferred when empty. Use mysql://... before increasing replicas.
+  # SQLite is inferred when empty and stored on a chart-managed PVC.
+  # Use mysql://... before increasing replicas.
   storeUrl: ""
   replicas: 1
   rpcPort: 9010
   webPort: 9011
+
+  storage:
+    # Requested capacity for the default single-replica SQLite PVC.
+    size: "1Gi"
 
   resources:
     requests:

--- a/curvine-runtime/values.yaml
+++ b/curvine-runtime/values.yaml
@@ -231,6 +231,24 @@ worker:
   # Additional volume mounts
   extraVolumeMounts: []
 
+# Standalone Transfer service configuration.
+# Disabled by default to preserve existing Master and Worker deployments.
+transfer:
+  enabled: false
+  # SQLite is inferred when empty. Use mysql://... before increasing replicas.
+  storeUrl: ""
+  replicas: 1
+  rpcPort: 9010
+  webPort: 9011
+
+  resources:
+    requests:
+      cpu: "500m"
+      memory: "1Gi"
+    limits:
+      cpu: "1000m"
+      memory: "2Gi"
+
 # Service configuration
 service:
   master:
@@ -307,6 +325,9 @@ config:
 #       max_connections: "1000"
 #     client:
 #       block_size_str: "128MB"
+#     transfer:
+#       max_running_transfers: 128
+#       lease_timeout: "180s"
 #     log:
 #       level: "DEBUG"
 configOverrides:
@@ -314,4 +335,5 @@ configOverrides:
   journal: {}
   worker: {}
   client: {}
+  transfer: {}
   log: {}


### PR DESCRIPTION
# Summary

Deploy the standalone Curvine Transfer service when `transfer.enabled=true`, with a generated in-cluster Service endpoint, shared cluster configuration, and durable default SQLite metadata.

This PR is blocked for production rollout until a released, immutable Curvine runtime image includes Transfer. The current latest release (`v0.4.0-alpha`) predates the Transfer-enabled Curvine main branch.

# Issue Describe / Design

Related to CurvineIO/curvine#1040.

The chart keeps Transfer disabled by default, preserving the existing Master Load API path. When enabled, it creates a Deployment and ClusterIP Service, writes the Service FQDN to `[transfer].hostname`, and leaves `endpoints` empty so Curvine infers `hostname:rpc_port`.

An empty `transfer.storeUrl` uses the inferred single-replica SQLite store. The chart creates a `ReadWriteOnce` PVC without `storageClassName`, letting Kubernetes choose the default StorageClass. The SQLite Deployment uses `Recreate` to prevent concurrent attachment during replacement, and Helm retains the PVC on uninstall. MySQL remains mandatory for multiple Transfer replicas and recommended for high availability.

# Changes

| Module / File | Change | Impact on existing behavior |
| ------------- | ------ | --------------------------- |
| `curvine-runtime/templates/transfer-*.yaml` | Add conditional Transfer Deployment, Service, and default SQLite PVC. | No Transfer workload or PVC when disabled. |
| `curvine-runtime/templates/configmap.yaml` | Render `[transfer]` config with generated Service DNS. | Existing Master/Worker configuration is unchanged while disabled. |
| `curvine-runtime/values.*` | Add minimal chart-managed Transfer values and SQLite PVC capacity. | Transfer defaults to disabled. |
| `curvine-runtime/README.md` | Document deployment, persistent SQLite behavior, MySQL boundary, endpoint inference, and parameters. | Operator guidance only. |

# Test verified

| Test case | Result | Notes |
| --------- | ------ | ----- |
| `helm lint curvine-runtime` | PASS | |
| `helm template` with Transfer disabled | PASS | No Transfer resource or SQLite PVC. |
| `helm template` with default SQLite | PASS | Renders a default-StorageClass PVC, `Recreate` strategy, and PVC mount. |
| `helm template` with MySQL | PASS | Renders no local SQLite PVC or `Recreate` strategy. |
| Minikube Helm install and upgrade | PASS | Earlier validation with local runtime image, MySQL store, Service `/readyz`, in-cluster `cv transfer list`, then `formatMaster=false` upgrade. |

# Dependencies

- Related PRs: CurvineIO/curvine#1411, CurvineIO/curvine#1412
- Related issues: CurvineIO/curvine#1040
- Blocks / blocked by: a released Curvine runtime image that includes Transfer.